### PR TITLE
[Feat] Add inclusive filter for markdown files

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,7 +24,7 @@ export const defaultUserOptions = {
     excludePaths: [] as string[],
     /**
      * filter specific files and tasks only from these files are rendered */
-    fileFilter: "" as string,
+    fileFilter: [] as string[],
     /**
      * Use tags filters to filter tasks without specific tags out or not.
      */
@@ -618,6 +618,22 @@ export class TasksCalendarSettingTab extends PluginSettingTab {
                     const values = v.split(',');
                     const valuesTrimed = values.map(p => p.trim()).filter(p => p.length > 0);
                     await this.onOptionUpdate({ excludePaths: valuesTrimed });
+                })
+            })
+
+        new Setting(containerEl)
+            .setName("Include Paths")
+            .setDesc(TasksCalendarSettingTab.createFragmentWithHTML(
+                "Include tasks match specific paths (folders, files). \n\
+                <p style=color:red;>NOTE that no prefix or trailing '/' needed, unless you want to filter the entire vault out.</p>"
+            ))
+            .addTextArea(ta => {
+                ta.setPlaceholder("comma separated file paths, e.g.: path1,path2/path3,path4.md");
+                ta.setValue(this.plugin.userOptions.fileFilter.join(","));
+                ta.onChange(async v => {
+                    const values = v.split(',');
+                    const valuesTrimed = values.map(p => p.trim()).filter(p => p.length > 0);
+                    await this.onOptionUpdate({ fileFilter: valuesTrimed });
                 })
             })
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,7 +24,7 @@ export const defaultUserOptions = {
     excludePaths: [] as string[],
     /**
      * filter specific files and tasks only from these files are rendered */
-    fileFilter: [] as string[],
+    includePaths: [] as string[],
     /**
      * Use tags filters to filter tasks without specific tags out or not.
      */

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -63,12 +63,12 @@ export class TasksTimelineView extends BaseTasksView {
     }
 
     onReloadTasks() {
-        const pathFilter = this.userOptionModel.get("excludePaths") || [];
-        const fileFilter = this.userOptionModel.get("fileFilter") || [];
+        const fileExcludeFilter = this.userOptionModel.get("excludePaths") || [];
+        const fileIncludeFilter = this.userOptionModel.get("includePaths") || [];
         const fileIncludeTagsFilter = this.userOptionModel.get("fileIncludeTags") || [];
         const fileExcludeTagsFilter = this.userOptionModel.get("fileExcludeTags") || [];
         const adapter = new ObsidianTaskAdapter(this.app);
-        adapter.generateTasksList(fileFilter, pathFilter, fileIncludeTagsFilter, fileExcludeTagsFilter).then(() => {
+        adapter.generateTasksList(fileIncludeFilter, fileExcludeFilter, fileIncludeTagsFilter, fileExcludeTagsFilter).then(() => {
             const taskList = adapter.getTaskList();
             this.parseTasks(taskList).then(tasks => {
                 const taskfiles = this.userOptionModel.get("taskFiles");

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -64,10 +64,11 @@ export class TasksTimelineView extends BaseTasksView {
 
     onReloadTasks() {
         const pathFilter = this.userOptionModel.get("excludePaths") || [];
+        const fileFilter = this.userOptionModel.get("fileFilter") || [];
         const fileIncludeTagsFilter = this.userOptionModel.get("fileIncludeTags") || [];
         const fileExcludeTagsFilter = this.userOptionModel.get("fileExcludeTags") || [];
         const adapter = new ObsidianTaskAdapter(this.app);
-        adapter.generateTasksList(pathFilter, fileIncludeTagsFilter, fileExcludeTagsFilter).then(() => {
+        adapter.generateTasksList(fileFilter, pathFilter, fileIncludeTagsFilter, fileExcludeTagsFilter).then(() => {
             const taskList = adapter.getTaskList();
             this.parseTasks(taskList).then(tasks => {
                 const taskfiles = this.userOptionModel.get("taskFiles");


### PR DESCRIPTION
This adds an option in the settings called "Include Files" that is the opposite of the "Exclude Files". This allows the ability to only look for tasks in the listed files.

Related to issue: #50 