### PR TITLE
fix: linter action no longer fails on tag push

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,6 +2,8 @@ name: Eslinter Fix and Push CI
 
 on:
   push:
+    branches:
+      - "**"
 
 jobs:
   linter:


### PR DESCRIPTION
Currently, the GitHub Action that automatically applies Eslint changes fails when pushing a tag. This can be circumvented by including the branch filter in the `on` directive.

The double asterisks pattern `**` is to make sure that it matches branch names with forward slashes in them, as per the [pattern documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags).

This edit was a collaboration with @stelcodes 🐧