### PR TITLE
feat: add convert24HourTimePrefix option

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -171,6 +171,10 @@ export const defaultUserOptions = {
      * If disabled, icons defined by the theme will be used.
      */
     useBuiltinStyle: true as boolean,
+    /**
+     * Convert a 24 hour time prefix in task description (15:30) to 12 hour time with am/pm (3:30 pm)
+     */
+	convert24HourTimePrefix: false as boolean,
 };
 export type UserOption = typeof defaultUserOptions;
 
@@ -508,6 +512,16 @@ export class TasksCalendarSettingTab extends PluginSettingTab {
                 ta.onChange(async v => {
                     await this.onOptionUpdate({ sort: v });
                 })
+            })
+
+        new Setting(containerEl)
+            .setName("Convert Time Prefix")
+            .setDesc("Convert 24 hour time prefix to 12 hour time with am/pm. \n\
+			    For example, 15:30 at the beginning of a task will become 3:30 pm.\n\
+			    This is applied after sorting, enabling a chronological ordering.")
+            .addToggle(async tg => {
+                tg.setValue(this.plugin.userOptions.convert24HourTimePrefix);
+                tg.onChange(async v => await this.onOptionUpdate({ convert24HourTimePrefix: v }));
             })
 
         new Setting(containerEl)

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -171,6 +171,17 @@ export class TasksTimelineView extends BaseTasksView {
             }
         }
 
+		if (this.userOptionModel.get("convert24HourTimePrefix")) {
+			taskList = taskList.map((t: TaskDataModel) => {
+				if (!t.visual || t.visual.length < 5) return t;
+				const timePrefix = moment(t.visual.substring(0,5), "HH:mm", true);
+				if (!timePrefix.isValid()) return t;
+				const updatedTimePrefix = timePrefix.format("h:mm a");
+				t.visual = updatedTimePrefix + t.visual.substring(5);
+				return t;
+			});
+		}
+
         return taskList;
     }
 


### PR DESCRIPTION
This commit adds a feature that alters the display/visual text of a task
when it is prefixed with a timestamp in 24-hour format. It must be 5
digits in the format "09:00" or "23:45". When this setting is enabled,
any 24-hour timestamp at the very beginning of a task will be visually
converted into 12-hour format with an "am" or "pm" after. This allows
tasks to be sortable by time (24-hour format is sortable, 12-hour format
is not) while having the option to display the times in the 12-hour
format if the user finds it easier to read.
