### PR TITLE
Enhancements: User Control for View on Startup (Issue #70) and Fix for Sidebar Position (Issue #68)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -71,6 +71,13 @@ export default class TasksCalendarWrapper extends Plugin {
 		if (type !== TIMELINE_VIEW) {
 			return;
 		}
+
+        const leaves = this.app.workspace.getLeavesOfType(type);
+		if (leaves.length > 0) {
+			this.app.workspace.revealLeaf(leaves[0]);
+			return;
+		}
+
 		this.app.workspace.detachLeavesOfType(type);
 		try {
 			await this.app.workspace.getRightLeaf(false).setViewState({
@@ -78,9 +85,9 @@ export default class TasksCalendarWrapper extends Plugin {
 				active: true,
 			});
 
-			this.app.workspace.revealLeaf(
-				this.app.workspace.getLeavesOfType(type).first()!
-			);
+			//  this.app.workspace.revealLeaf(
+			//	  this.app.workspace.getLeavesOfType(type).first()!
+			//. );
 		} catch (e) {
 			console.log(e)
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,8 +19,12 @@ export default class TasksCalendarWrapper extends Plugin {
 				return view;
 			}
 		);
-		this.app.workspace.onLayoutReady(async () => await this.activateView(TIMELINE_VIEW))
-		//this.app.workspace.getActiveViewOfType(TasksTimelineView)?.onUpdateOptions({ ...this.userOptions })
+        if (this.userOptions.openViewOnStartup)
+			this.app.workspace.onLayoutReady(
+				async () => await this.activateView(TIMELINE_VIEW)
+			);
+		// this.app.workspace.onLayoutReady(async () => await this.initView(TIMELINE_VIEW))
+		// this.app.workspace.getActiveViewOfType(TasksTimelineView)?.onUpdateOptions({ ...this.userOptions })
 		// This adds a simple command that can be triggered anywhere
 
 		this.addCommand({
@@ -84,13 +88,8 @@ export default class TasksCalendarWrapper extends Plugin {
 				type: type,
 				active: true,
 			});
-
-			//  this.app.workspace.revealLeaf(
-			//	  this.app.workspace.getLeavesOfType(type).first()!
-			//. );
 		} catch (e) {
 			console.log(e)
 		}
-
-	}
+    }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,10 @@ const sortOptions = {
 };
 export const defaultUserOptions = {
     /**
+	 * Open the view on startup or not
+	 */
+	openViewOnStartup: false as boolean,
+    /**
      * filter empty items out or not, if not, the raw text of empty items will be displayed
      */
     filterEmpty: true as boolean,
@@ -204,6 +208,17 @@ export class TasksCalendarSettingTab extends PluginSettingTab {
 
         containerEl.createEl("h1", { text: 'Timeline Settings' });
         containerEl.createEl("h2", { text: "UI Settings" });
+
+        new Setting(containerEl)
+			.setName("Open View On Startup")
+			.setDesc("Open the view on startup or not.")
+			.addToggle(async (tg) => {
+				tg.setValue(this.plugin.userOptions.openViewOnStartup);
+				tg.onChange(
+					async (v) =>
+						await this.onOptionUpdate({ openViewOnStartup: v })
+				);
+			});
 
         new Setting(containerEl)
             .setName("Use Builtin Style")


### PR DESCRIPTION
This PR resolves Issue #68 by adjusting the activateView function. The issue caused the task timeline view to reopen in the top-right sidebar by default, regardless of its previous location. The changes ensure that if a task timeline view is already open within the workspace, it will be revealed instead of opening a new one in a default location. 
This PR also introduces an openViewOnStartup option, enabling users to choose whether the task timeline view should auto-load on startup, as requested in Issue #70.